### PR TITLE
Add GH actions workflow that builds Windows and Linux binaries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,57 @@
+name: Build
+
+on:
+  workflow_dispatch:
+
+env:
+    DOTNET_VERSION: 7.0.x
+
+jobs:
+
+  build-and-publish:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macOS-latest, macos-14]
+        include:
+          - os: ubuntu-latest
+            runtime-identifier: linux-x64
+          - os: windows-latest
+            runtime-identifier: win-x64
+          - os: macOS-latest
+            runtime-identifier: osx-x64
+          - os: macos-14
+            runtime-identifier: osx-arm64
+      fail-fast: false
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: ${{ env.DOTNET_VERSION }}
+
+    - name: Nuget cache
+      uses: actions/cache@v4
+      with:
+        path:
+          ~/.nuget/packages
+        key: ${{ runner.os }}-nuget-${{ hashFiles('**/packages.lock.json') }}
+        restore-keys: |
+          ${{ runner.os }}-nuget-
+    - name: Build
+      run: dotnet build -c Release
+
+    - name: Publish Engine
+      run: dotnet publish Snail-Chess.Cmd/Snail-Chess.Cmd.csproj -c Release --runtime ${{ matrix.runtime-identifier }} -o artifacts/${{ matrix.runtime-identifier }}
+
+    - name: Upload Snail-Chess-${{ github.run_number }}-${{ matrix.runtime-identifier }} artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: Snail-Chess-${{ github.run_number }}-${{ matrix.runtime-identifier }}
+        path: |
+          artifacts/${{ matrix.runtime-identifier }}/
+          !artifacts/**/*.pdb
+        if-no-files-found: error

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,16 +13,12 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macOS-latest, macos-14]
+        os: [ubuntu-latest, windows-latest]
         include:
           - os: ubuntu-latest
             runtime-identifier: linux-x64
           - os: windows-latest
             runtime-identifier: win-x64
-          - os: macOS-latest
-            runtime-identifier: osx-x64
-          - os: macos-14
-            runtime-identifier: osx-arm64
       fail-fast: false
 
     steps:


### PR DESCRIPTION
This PR adds a simple GH actions script that builds your engine for both Windows and Linux x64 and uploads the binaries.

It's configured so that you can trigger it manually from GitHub going to `Actions` -> `Build` -> `Run workflow`, but it can be easily changed to run automatically on every push to master (or to any branch).

You'll get something like [this run](https://github.com/eduherminio/Snail-Chess/actions/runs/11097686936) but in your repository (binaries can be found at the bottom).

Note that AOT isn't needed to make the binaries self-contained, but using it prevents builds for other runtimes (see errors in [this run](https://github.com/eduherminio/Snail-Chess/actions/runs/11097646242)). You could always just enable self-contained executables for those runtimes (or in general for all of them, since that's done by default for AOT ones) and disable AOT flag for macOS runtimes.

You can find a more complete version of this in [my CI file](https://github.com/lynx-chess/Lynx/blob/main/.github/workflows/ci.yml) or in [my release file](https://github.com/lynx-chess/Lynx/blob/main/.github/workflows/release.yml), with examples of how to use conditionals, configure it to run on every build, etc.

Happy to help or clarify anything!